### PR TITLE
Fix case typo causing compiler complaints

### DIFF
--- a/rcsc/action/body_stop_dash.h
+++ b/rcsc/action/body_stop_dash.h
@@ -30,7 +30,7 @@
 /////////////////////////////////////////////////////////////////////
 
 #ifndef RCSC_ACTION_BODY_STOP_DASH_H
-#define RCSC_ACTION_BODy_STOP_DASH_H
+#define RCSC_ACTION_BODY_STOP_DASH_H
 
 #include <rcsc/player/soccer_action.h>
 


### PR DESCRIPTION
The last letter of "BODY" is "BODy" in the "define" line; this causes compiler complaints like the following during hfo-py builds:

> #ifndef RCSC_ACTION_BODY_STOP_DASH_H
>         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
> build/librcsc-prefix/src/librcsc/rcsc/action/body_stop_dash.h:33:9: note: 
>       'RCSC_ACTION_BODy_STOP_DASH_H' is defined here; did you mean 'RCSC_ACTION_BODY_STOP_DASH_H'?
> #define RCSC_ACTION_BODy_STOP_DASH_H

-Allen