### PR TITLE
Virtual functions with no code and non-void return: =0; silence compiler warning

### DIFF
--- a/rcsc/common/soccer_agent.h
+++ b/rcsc/common/soccer_agent.h
@@ -138,8 +138,7 @@ protected:
     void handleMessage() = 0;
 
     virtual
-    bool handleMessageStep()
-      { }
+    bool handleMessageStep() = 0;
 
     /*!
       \brief (virtual) handle offline client log message in offline client mode.
@@ -163,8 +162,7 @@ protected:
 
     virtual
     bool handleTimeoutStep( const int timeout_count,
-                            const int waited_msec )
-      { }
+                            const int waited_msec ) = 0;
 
     /*!
       \brief (pure virtual) handle exit event


### PR DESCRIPTION
clang kept complaining that various virtual functions, defined with `{ }` instead of `= 0;`, were not returning the proper type (and weren't supposed to return `void`). This has them defined with `= 0;`.

-Allen