### PR TITLE
Fix obscure seqFault

### DIFF
--- a/rcsc/action/body_smart_kick.cpp
+++ b/rcsc/action/body_smart_kick.cpp
@@ -110,10 +110,13 @@ Body_SmartKick::execute( PlayerAgent * agent )
                       M_sequence.power_,
                       (int)M_sequence.pos_list_.size() );
 
-        Vector2D vel = M_sequence.pos_list_.front() - wm.ball().pos();
-        Vector2D kick_accel = vel - wm.ball().vel();
-        agent->doKick( kick_accel.r() / wm.self().kickRate(),
+        if ( wm.ball().posValid() )
+        {
+          Vector2D vel = M_sequence.pos_list_.front() - wm.ball().pos();
+          Vector2D kick_accel = vel - wm.ball().vel();
+          agent->doKick( kick_accel.r() / wm.self().kickRate(),
                        kick_accel.th() - wm.self().body() );
+        }
         return true;
     }
 


### PR DESCRIPTION
When a high level random agent is allowed to run for a large number of episodes ( ~1Million ), it is seen to periodically go down with a segmentation fault at line        
https://github.com/mhauskn/librcsc/blob/95d560e3ca52187b401bd3323a967f92072e0623/rcsc/action/body_smart_kick.cpp#L114

This happens almost definately after anywhere between 60K - 200K episodes.

Adding the if condition seems to fix it.
